### PR TITLE
Removed deprecated image from Firestore backup GitHub Action

### DIFF
--- a/.github/workflows/backup.yaml
+++ b/.github/workflows/backup.yaml
@@ -12,7 +12,7 @@ jobs:
   backup:
     runs-on: ubuntu-latest
     steps:
-    - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+    - uses: google-github-actions/setup-gcloud@master
       with:
         service_account_key: ${{ secrets.GCP_SA_KEY }}
         export_default_credentials: true


### PR DESCRIPTION
`GoogleCloudPlatform/github-actions/setup-gcloud` is deprecated and shouldn't be used anymore. If you don't remove it, you will get this error:
> Thank you for using setup-gcloud Action. GoogleCloudPlatform/github-actions/setup-gcloud has been deprecated, please switch to google-github-actions/setup-gcloud.